### PR TITLE
Use npx instead of npm exec to support npm 6+

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "url": "https://github.com/slackapi/bolt-js-template/issues"
   },
   "dependencies": {
-    "@slack/bolt": "^3.10.0",
+    "@slack/bolt": "slackapi/bolt-js#add-app-function",
     "dotenv": "~16.0.0"
   },
   "devDependencies": {

--- a/slack.json
+++ b/slack.json
@@ -1,5 +1,5 @@
 {
   "hooks": {
-    "get-hooks": "npm exec --package=@slack/bolt slack-cli-get-hooks"
+    "get-hooks": "npx -q --no-install -p @slack/bolt slack-cli-get-hooks"
   }
 }


### PR DESCRIPTION
`npm exec` is not available in npm v6 (thanks for catching this @srajiang !) so moving to use `npx` instead, which is supported in older versions of npm.

This PR relies on https://github.com/slackapi/bolt-js/pull/1451.

Additionally, `npx` seems to not work very well with `npm link`ed packages, so need to explicitly reference the work-in-progress bolt-js branch to have all this work seamlessly together.